### PR TITLE
feat: 头像缓存时长设置为300s

### DIFF
--- a/app/http/controllers/avatar_controller.go
+++ b/app/http/controllers/avatar_controller.go
@@ -94,7 +94,7 @@ func (r *AvatarController) Avatar(ctx http.Context) http.Response {
 		return ctx.Response().String(http.StatusInternalServerError, "WeAvatar 服务出现错误")
 	}
 
-	ctx.Response().Header("Cache-Control", "public, max-age=3600")
+	ctx.Response().Header("Cache-Control", "public, max-age=300")
 	ctx.Response().Header("Avatar-By", "weavatar.com")
 	ctx.Response().Header("Avatar-From", from)
 	ctx.Response().Header("Last-Modified", lastModified.SubHours(8).SetTimezone(carbon.GMT).ToRfc7231String())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 调整了头像控制器的缓存策略，将缓存持续时间从一小时减少到五分钟，以确保客户端更频繁地接收到更新内容。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->